### PR TITLE
Separating Ruby version in ENV

### DIFF
--- a/base/ruby210/Dockerfile
+++ b/base/ruby210/Dockerfile
@@ -1,12 +1,12 @@
 FROM codenvy/shellinabox
 
 ENV DEBIAN_FRONTEND noninteractive
-
+ENV RUBY_VERSION 2.1.0
 RUN sudo apt-get update && \
     sudo -E apt-get install -y nodejs curl && \
     sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 && \
     curl -sSL https://get.rvm.io | sudo bash -s stable && \
     sudo /bin/bash -l -c "rvm requirements" && \
-    sudo /bin/bash -l -c "rvm install 2.1.0"
+    sudo /bin/bash -l -c "rvm install ${RUBY_VERSION}"
 
 RUN sudo sed -i '/exec "$@"/isource /etc/profile.d/rvm.sh\n' /entrypoint.sh


### PR DESCRIPTION
This way one can override the Ruby version required for a container