### PR TITLE
Update Dockerfile

### DIFF
--- a/base/shellinabox/Dockerfile
+++ b/base/shellinabox/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     usermod -u 1000 user && \
     echo "secret\nsecret" | passwd user && apt-get clean && \
     sudo rm -rf /var/lib/apt/lists/* && \
-    RUN sudo chown user:user -R /opt && \
+    sudo chown user:user -R /opt && \
     cd /opt && unzip shellinabox.zip && \
     rm -rf /opt/shellinabox.zip && \
     sudo chmod 755 /entrypoint.sh

--- a/base/shellinabox/Dockerfile
+++ b/base/shellinabox/Dockerfile
@@ -1,21 +1,6 @@
 FROM debian:jessie
 
-RUN apt-get update && \
-    apt-get -y install sudo procps wget unzip mc gcc make && \
-    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 5001 -G users,sudo -d /home/user --shell /bin/bash -m user && \
-    echo "secret\nsecret" | passwd user && apt-get clean
-
-RUN usermod -u 1000 user
-
-USER user
-
-EXPOSE 4200
-
-ENV CODENVY_WEB_SHELL_PORT 4200
-
 ADD entrypoint.sh /entrypoint.sh
-
 # Shellinabox binaries are added. To build Shellinabox from source run:
 #
 # wget -qO- "https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz" | tar -zx --strip-components=1 -C /opt/shellinabox
@@ -28,12 +13,24 @@ ADD entrypoint.sh /entrypoint.sh
 # /shellinabox/shellinabox/black-on-white.css
 # /shellinabox/shellinabox/white-on-black.css
 # Once done, zip the archive to be injected into the image
-
 ADD shellinabox.zip /opt/shellinabox.zip
 
-RUN sudo chown user:user -R /opt && \
+RUN apt-get update && \
+    apt-get -y install sudo procps wget unzip mc gcc make && \
+    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    useradd -u 5001 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    usermod -u 1000 user && \
+    echo "secret\nsecret" | passwd user && apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    RUN sudo chown user:user -R /opt && \
     cd /opt && unzip shellinabox.zip && \
     rm -rf /opt/shellinabox.zip && \
     sudo chmod 755 /entrypoint.sh
+
+USER user
+
+EXPOSE 4200
+
+ENV CODENVY_WEB_SHELL_PORT 4200
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
optimizations that saves disk space and build time, could still be better if shellinabox.zip can be a zipped tar file instead so we can just do:

wget -qO- https://raw.githubusercontent.com/codenvy/dockerfiles/master/base/shellinabox/shellinabox.tgz | tar xz -C /opt/