### PR TITLE
Variable expansion on command lines should be quoted

### DIFF
--- a/base/shellinabox/entrypoint.sh
+++ b/base/shellinabox/entrypoint.sh
@@ -19,6 +19,6 @@ else
   theme="/opt/shellinabox/shellinabox/black-on-white.css"
 fi
 
-sudo /opt/shellinabox/shellinaboxd -b --css $theme --no-beep --service $service
+sudo /opt/shellinabox/shellinaboxd -b --css "$theme" --no-beep --service "$service"
 
 exec "$@"


### PR DESCRIPTION
let's say I want to provide the following service definition in my Dockerfile:

ENV SHELL_IN_A_BOX_SERVICE /:user:users:/home/user:/usr/bin/tmux new -A -s runner

The variable is set correctly by Docker, however without quotes in this script the new -A -s and runner items end up being parsed as additional arguments to shellinaboxd rather than being included as part of the --service definition.