### PR TITLE
Add TOMCAT_HOME env var to CentOS image

### DIFF
--- a/centos_jdk8/Dockerfile
+++ b/centos_jdk8/Dockerfile
@@ -14,7 +14,8 @@ LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:
 
 ENV MAVEN_VERSION=3.2.2 \
     JAVA_VERSION=8u45 \
-    JAVA_VERSION_PREFIX=1.8.0_45
+    JAVA_VERSION_PREFIX=1.8.0_45 \
+    TOMCAT_HOME=/home/user/tomcat8
 
 ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
     M2_HOME=/opt/apache-maven-$MAVEN_VERSION


### PR DESCRIPTION
web-java-spring examples don't work on CentOS image, because TOMCAT_HOME is not set.