### PR TITLE
creating a Dockerfile for support dotnet core

### DIFF
--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -4,41 +4,22 @@
 # Contributors:
 # Abel García Dorta <mercuriete@gmail.com> 
 
-FROM ubuntu:14.04
+FROM codenvy/ubuntu_jre
 
 MAINTAINER mercuriete@gmail.com
 
-RUN apt-get update && \
-    apt-get -y install \
-    openssh-server \
-    sudo \
-    procps \
-    wget \
-    unzip \
-    mc \
-    ca-certificates \
-    curl \
-    software-properties-common \
-    python-software-properties && \
-    mkdir /var/run/sshd && \
-    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
-    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
-    echo "secret\nsecret" | passwd user && \
-    add-apt-repository ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install git subversion -y && \
-    echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
+USER root
+RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
     apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
     apt-get update && \
     apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
     apt-get clean && \
     apt-get -y autoremove \
     && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/* && \
-    echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && chmod a+x /home/user/entrypoint.sh
+    && rm -rf /var/lib/apt/lists/*
 ENV LANG C.UTF-8
 USER user
 EXPOSE 22 4403
 WORKDIR /projects
-ENTRYPOINT ["/home/user/entrypoint.sh"]
+CMD sudo /usr/sbin/sshd -D && \
+    tail -f /dev/null

--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -1,0 +1,44 @@
+# LICENCE: Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# Contributors:
+# Abel García Dorta <mercuriete@gmail.com> 
+
+FROM ubuntu:14.04
+
+MAINTAINER mercuriete@gmail.com
+
+RUN apt-get update && \
+    apt-get -y install \
+    openssh-server \
+    sudo \
+    procps \
+    wget \
+    unzip \
+    mc \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    python-software-properties && \
+    mkdir /var/run/sshd && \
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
+    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    echo "secret\nsecret" | passwd user && \
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install git subversion -y && \
+    echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
+    apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
+    apt-get update && \
+    apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
+    apt-get clean && \
+    apt-get -y autoremove \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* && \
+    echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && chmod a+x /home/user/entrypoint.sh
+ENV LANG C.UTF-8
+USER user
+EXPOSE 22 4403
+WORKDIR /projects
+ENTRYPOINT ["/home/user/entrypoint.sh"]


### PR DESCRIPTION
I'm am trying to get dotnet core working in eclipse che.

so first to create a template i should create a image with the enviroment.

I started from condenvy/ubuntu-jre
and then i modified the dockerfile to follow this tutorial:
https://www.microsoft.com/net/core#ubuntu

it is just installing a new key for apt-get
install the package and that it.

for test that the image is working:

dotnet new
dotnet restore
dotnet run
