### PR TITLE
Adding support for dotnet core.

### DIFF
--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -4,41 +4,22 @@
 # Contributors:
 # Abel García Dorta <mercuriete@gmail.com> 
 
-FROM ubuntu:14.04
+FROM codenvy/ubuntu_jre
 
 MAINTAINER mercuriete@gmail.com
 
-RUN apt-get update && \
-    apt-get -y install \
-    openssh-server \
-    sudo \
-    procps \
-    wget \
-    unzip \
-    mc \
-    ca-certificates \
-    curl \
-    software-properties-common \
-    python-software-properties && \
-    mkdir /var/run/sshd && \
-    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
-    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
-    echo "secret\nsecret" | passwd user && \
-    add-apt-repository ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install git subversion -y && \
-    echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
+USER root
+RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
     apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
     apt-get update && \
     apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
     apt-get clean && \
     apt-get -y autoremove \
     && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/* && \
-    echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && chmod a+x /home/user/entrypoint.sh
+    && rm -rf /var/lib/apt/lists/*
 ENV LANG C.UTF-8
 USER user
 EXPOSE 22 4403
 WORKDIR /projects
-ENTRYPOINT ["/home/user/entrypoint.sh"]
+CMD sudo /usr/sbin/sshd -D && \
+    tail -f /dev/null

--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -8,18 +8,15 @@ FROM codenvy/ubuntu_jre
 
 MAINTAINER mercuriete@gmail.com
 
-USER root
-RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
-    apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
-    apt-get update && \
-    apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
-    apt-get clean && \
-    apt-get -y autoremove \
-    && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" | sudo tee --append /etc/apt/sources.list.d/dotnetdev.list && \
+    sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
+    sudo apt-get update && \
+    sudo apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
+    sudo apt-get clean && \
+    sudo apt-get -y autoremove && \
+    sudo apt-get -y clean && \
+    sudo rm -rf /var/lib/apt/lists/*
 ENV LANG C.UTF-8
-USER user
-EXPOSE 22 4403
 WORKDIR /projects
-CMD sudo /usr/sbin/sshd -D && \
-    tail -f /dev/null
+CMD tail -f /dev/null
+

--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -1,0 +1,44 @@
+# LICENCE: Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# Contributors:
+# Abel García Dorta <mercuriete@gmail.com> 
+
+FROM ubuntu:14.04
+
+MAINTAINER mercuriete@gmail.com
+
+RUN apt-get update && \
+    apt-get -y install \
+    openssh-server \
+    sudo \
+    procps \
+    wget \
+    unzip \
+    mc \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    python-software-properties && \
+    mkdir /var/run/sshd && \
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
+    echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    echo "secret\nsecret" | passwd user && \
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install git subversion -y && \
+    echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list && \
+    apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
+    apt-get update && \
+    apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
+    apt-get clean && \
+    apt-get -y autoremove \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* && \
+    echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && chmod a+x /home/user/entrypoint.sh
+ENV LANG C.UTF-8
+USER user
+EXPOSE 22 4403
+WORKDIR /projects
+ENTRYPOINT ["/home/user/entrypoint.sh"]


### PR DESCRIPTION
I wanted to add support for the new tool from microsoft dotnet core.

so I started FROM codenvy/ubuntu_jre

and then I followed this tutorial from microsoft:
https://www.microsoft.com/net/core#ubuntu

I build already the image an can be downloaded from:
https://hub.docker.com/r/mercuriete/dotnet-core/


This toolchain works with this examples:
https://github.com/aspnet/cli-samples

There are only one weird thing. When you are installing dotnet core, there are some scary warning:

Setting up dotnet-dev-1.0.0-preview1-002702 (1.0.0-preview1-002702-1) ...
This software may collect information about you and your use of the software, and send that to Microsoft.
Please visit http://aka.ms/dotnet-cli-eula for more information.


When you follow the link, there are no EULA at all.
It is possible that a open source application could have an EULA?

This is my first pull request so be nice :smile: 

Thanks for your work!

EDIT: I just realised that maybe EXPOSE 5000 is needed for ASP.NET core applications.
          I don't know how eclipse che redirects the ports.
EDIT2: I did a factory to test it 
[![Contribute](http://beta.codenvy.com/factory/resources/codenvy-contribute.svg)](http://beta.codenvy.com/f?name=dotnet-factory&user=mercuriete)

EDIT3: the desision to create a new dockerfile and not extending the previous aspnet dockerfile is because dotnet core dont replace ASP.NET mono compiler it seems like is a subset of the full sdk.
https://github.com/aspnet/cli-samples/issues/55
I need time to think if i can extend the actual aspnet dockerfile and install dotnet core on top of it.
