### PR TITLE
Update .NET Core Preview from v1 to v2

### DIFF
--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER mercuriete@gmail.com
 RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" | sudo tee --append /etc/apt/sources.list.d/dotnetdev.list && \
     sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 &&\
     sudo apt-get update && \
-    sudo apt-get install dotnet-dev-1.0.0-preview1-002702 -y && \
+    sudo apt-get install dotnet-dev-1.0.0-preview2-003121 -y && \
     sudo apt-get clean && \
     sudo apt-get -y autoremove && \
     sudo apt-get -y clean && \


### PR DESCRIPTION
Change to the official release of .NET Core and allows proper usage of NuGet as a result.