### PR TITLE
Add myself as contributor to dotnet_core

### DIFF
--- a/dotnet_core/Dockerfile
+++ b/dotnet_core/Dockerfile
@@ -5,6 +5,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 # Contributors:
 # Abel García Dorta <mercuriete@gmail.com> 
+# Roger Narayan <narayanroger@gmail.com>
 
 FROM codenvy/ubuntu_jre
 


### PR DESCRIPTION
The builds of the dotnet_core dockerfile have failed due to an error @ npm/npm#13284 aka the 502 bad gateway error. The builds should start working now because a quick fix was implemented