### PR TITLE
Upgrade base Ubuntu image to 16.04

### DIFF
--- a/ubuntu_jre/Dockerfile
+++ b/ubuntu_jre/Dockerfile
@@ -6,7 +6,7 @@
 # Contributors:
 # Codenvy, S.A. - initial API and implementation
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ENV JAVA_VERSION=8u65 \
     JAVA_VERSION_PREFIX=1.8.0_65


### PR DESCRIPTION
This is in preparation for adding support for PHP 7 stack.
