### PR TITLE
Update alpine base image to support che-in-che

### DIFF
--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -6,41 +6,87 @@
 # Contributors:
 # Codenvy, S.A. - initial API and implementation
 
-FROM alpine:3.3
+FROM docker:1.12.0
 
 # Here we use several hacks collected from https://github.com/gliderlabs/docker-alpine/issues/11:
 # 1. install GLibc (which is not the cleanest solution at all)
 # 2. hotfix /etc/nsswitch.conf, which is apperently required by glibc and is not used in Alpine Linux
 
-ENV JAVA_VERSION=8 \
-    JAVA_UPDATE=72 \
-    JAVA_BUILD=15 \
-    JAVA_HOME="/usr/lib/jvm/default-jvm" \
-    MAVEN_VERSION=3.3.9 \
-    TOMCAT_HOME="/home/user/tomcat8"
-ENV M2_HOME="/usr/lib/apache-maven-$MAVEN_VERSION"
+ENV JAVA_VERSION_MAJOR=8 \
+    JAVA_VERSION_MINOR=92 \
+    JAVA_VERSION_BUILD=14 \
+    JAVA_PACKAGE=jdk \
+    JAVA_JCE=standard \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
+    GLIBC_VERSION=2.23-r3 \
+    LANG=C.UTF-8
 
 ENV PATH $JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
-RUN apk add --no-cache --virtual=build-dependencies wget ca-certificates && \
-    export ALPINE_GLIBC_BASE_URL="https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64" && \
-    export ALPINE_GLIBC_PACKAGE="glibc-2.21-r2.apk" && \
-    export ALPINE_GLIBC_BIN_PACKAGE="glibc-bin-2.21-r2.apk" && \
-    wget "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE" "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_BIN_PACKAGE" && \
-    apk add --no-cache --allow-untrusted "$ALPINE_GLIBC_PACKAGE" "$ALPINE_GLIBC_BIN_PACKAGE" && \
-    /usr/glibc/usr/bin/ldconfig "/lib" "/usr/glibc/usr/lib" && \
+ENV MAVEN_VERSION=3.3.9 \
+    M2_HOME="/usr/lib/apache-maven-$MAVEN_VERSION" \
+    TOMCAT_HOME="/home/user/tomcat8" 
+
+# do all in one step
+RUN apk upgrade --update && \
+    apk add --update libstdc++ curl ca-certificates bash && \
+    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
+    apk add --allow-untrusted /tmp/*.apk && \
+    rm -v /tmp/*.apk && \
+    ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
+    echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
+    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
+    mkdir /opt && \
+    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
+      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+    gunzip /tmp/java.tar.gz && \
+    tar -C /opt -xf /tmp/java.tar && \
+    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
+      curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
+        http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
+      cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+    fi && \
+    sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
+    apk del curl glibc-i18n && \
+    rm -rf /opt/jdk/*src.zip \
+           /opt/jdk/lib/missioncontrol \
+           /opt/jdk/lib/visualvm \
+           /opt/jdk/lib/*javafx* \
+           /opt/jdk/jre/plugin \
+           /opt/jdk/jre/bin/javaws \
+           /opt/jdk/jre/bin/jjs \
+           /opt/jdk/jre/bin/keytool \
+           /opt/jdk/jre/bin/orbd \
+           /opt/jdk/jre/bin/pack200 \
+           /opt/jdk/jre/bin/policytool \
+           /opt/jdk/jre/bin/rmid \
+           /opt/jdk/jre/bin/rmiregistry \
+           /opt/jdk/jre/bin/servertool \
+           /opt/jdk/jre/bin/tnameserv \
+           /opt/jdk/jre/bin/unpack200 \
+           /opt/jdk/jre/lib/javaws.jar \
+           /opt/jdk/jre/lib/deploy* \
+           /opt/jdk/jre/lib/desktop \
+           /opt/jdk/jre/lib/*javafx* \
+           /opt/jdk/jre/lib/*jfx* \
+           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
+           /opt/jdk/jre/lib/amd64/libprism_*.so \
+           /opt/jdk/jre/lib/amd64/libfxplugins.so \
+           /opt/jdk/jre/lib/amd64/libglass.so \
+           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
+           /opt/jdk/jre/lib/amd64/libjavafx*.so \
+           /opt/jdk/jre/lib/amd64/libjfx*.so \
+           /opt/jdk/jre/lib/ext/jfxrt.jar \
+           /opt/jdk/jre/lib/ext/nashorn.jar \
+           /opt/jdk/jre/lib/oblique-fonts \
+           /opt/jdk/jre/lib/plugin.jar \
+           /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    rm "$ALPINE_GLIBC_PACKAGE" "$ALPINE_GLIBC_BIN_PACKAGE" && \
-    apk add --update --no-cache openssh curl mc git subversion sudo unzip bash ca-certificates && \
-    cd "/tmp" && \
-    wget -q --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-        "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD}/jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    tar -xzf "jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    mkdir -p "/usr/lib/jvm" && \
-    mv "/tmp/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE}" "/usr/lib/jvm/java-${JAVA_VERSION}-oracle" && \
-    ln -s "java-${JAVA_VERSION}-oracle" "$JAVA_HOME" && \
-    ln -s "$JAVA_HOME/bin/"* "/usr/bin/" && \
-    rm -rf "$JAVA_HOME/"*src.zip && \
+    apk add --update --no-cache openssh curl mc git subversion sudo unzip bash ca-certificates openssl && \
+    cd /tmp && \
     wget -q "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && tar -xzf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
     mv "/tmp/apache-maven-$MAVEN_VERSION" "/usr/lib" && \
     rm "/tmp/"* && \
@@ -49,11 +95,14 @@ RUN apk add --no-cache --virtual=build-dependencies wget ca-certificates && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     PASS=$(openssl rand -base64 32) && \
     echo -e "${PASS}\n${PASS}" | passwd user && \
-    wget -q "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz" && tar -xzf "apache-tomcat-8.0.29.tar.gz" && \
-    mv /tmp/apache-tomcat-8.0.29 /home/user/tomcat8/ && \
-    rm -rf /home/user/tomcat8/webapps/* ** \
+    wget -q "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz" && \
+    tar -xzf "apache-tomcat-8.0.29.tar.gz" && \
+    mv apache-tomcat-8.0.29 /home/user/tomcat8/ && \
+    rm -rf /home/user/tomcat8/webapps/* && \
     rm /tmp/apache-tomcat-8.0.29.tar.gz && \
     chown -R user /home/user/
+
+ENV DOCKER_HOST=tcp://192.168.65.1
 
 EXPOSE 22 8000 8080
 

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -96,11 +96,11 @@ RUN apk upgrade --update && \
     rm /tmp/apache-tomcat-8.0.29.tar.gz && \
     chown -R user /home/user/
 
-ENV DOCKER_HOST=tcp://192.168.65.1
+ENV DOCKER_HOST=tcp://192.168.65.1 \
+    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
+    TOMCAT_HOME=/home/user/tomcat8
 
-ENV M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
-    TOMCAT_HOME=/home/user/tomcat8 \ 
-    PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
+ENV PATH=${PATH}:${JAVA_HOME}/bin:${M2_HOME}/bin
 
 EXPOSE 22 8000 8080
 

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -22,11 +22,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     MAVEN_VERSION=3.3.9 \
     LANG=C.UTF-8
 
-# Install basic utilities into our base image
+# do all in one step
 RUN apk upgrade --update && \
-    apk add --update --no-cachelibstdc++ curl ca-certificates bash openssh sudo openssl && \
-
-# Install minified JDK per: https://github.com/anapsix/docker-alpine-java
+    apk add --update libstdc++ curl ca-certificates bash openssh sudo unzip bash openssl && \
     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
     apk add --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \
@@ -81,26 +79,21 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-
-# Install maven
     cd /tmp && \
-    wget -q "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && tar -xzf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
+    wget -q "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && \ 
+    tar -xzf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
     mv "/tmp/apache-maven-$MAVEN_VERSION" "/usr/lib" && \
     rm "/tmp/"* && \
-
-# Configure the "user" to have passwordless access
     adduser -S user -h /home/user -s /bin/bash -G root -u 1000 && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     PASS=$(openssl rand -base64 32) && \
     echo -e "${PASS}\n${PASS}" | passwd user && \
     chown -R user /home/user/
 
-# Hard code the container to find the host's Docker daemon
-# Also setup the maven home
 ENV DOCKER_HOST=tcp://192.168.65.1 \
-    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION
+    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
+    TOMCAT_HOME=/home/user/tomcat8
 
-# Run this environment in separate command otherwise it will not pick up other values
 ENV PATH=${PATH}:${JAVA_HOME}/bin:${M2_HOME}/bin
 
 EXPOSE 22 8000 8080

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -22,9 +22,11 @@ ENV JAVA_VERSION_MAJOR=8 \
     MAVEN_VERSION=3.3.9 \
     LANG=C.UTF-8
 
-# do all in one step
+# Install basic utilities into our base image
 RUN apk upgrade --update && \
-    apk add --update libstdc++ curl ca-certificates bash && \
+    apk add --update --no-cachelibstdc++ curl ca-certificates bash openssh sudo openssl && \
+
+# Install minified JDK per: https://github.com/anapsix/docker-alpine-java
     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
     apk add --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \
@@ -79,27 +81,26 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    apk add --update --no-cache openssh curl mc git subversion sudo unzip bash ca-certificates openssl && \
+
+# Install maven
     cd /tmp && \
     wget -q "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && tar -xzf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
     mv "/tmp/apache-maven-$MAVEN_VERSION" "/usr/lib" && \
     rm "/tmp/"* && \
-    deluser svn && \
+
+# Configure the "user" to have passwordless access
     adduser -S user -h /home/user -s /bin/bash -G root -u 1000 && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     PASS=$(openssl rand -base64 32) && \
     echo -e "${PASS}\n${PASS}" | passwd user && \
-    wget -q "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz" && \
-    tar -xzf "apache-tomcat-8.0.29.tar.gz" && \
-    mv apache-tomcat-8.0.29 /home/user/tomcat8/ && \
-    rm -rf /home/user/tomcat8/webapps/* && \
-    rm /tmp/apache-tomcat-8.0.29.tar.gz && \
     chown -R user /home/user/
 
+# Hard code the container to find the host's Docker daemon
+# Also setup the maven home
 ENV DOCKER_HOST=tcp://192.168.65.1 \
-    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
-    TOMCAT_HOME=/home/user/tomcat8
+    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION
 
+# Run this environment in separate command otherwise it will not pick up other values
 ENV PATH=${PATH}:${JAVA_HOME}/bin:${M2_HOME}/bin
 
 EXPOSE 22 8000 8080

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -18,15 +18,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
+    MAVEN_VERSION=3.3.9 \
     LANG=C.UTF-8
-
-ENV PATH $JAVA_HOME/bin:$M2_HOME/bin:$PATH
-
-ENV MAVEN_VERSION=3.3.9 \
-    M2_HOME="/usr/lib/apache-maven-$MAVEN_VERSION" \
-    TOMCAT_HOME="/home/user/tomcat8" 
 
 # do all in one step
 RUN apk upgrade --update && \
@@ -104,6 +98,10 @@ RUN apk upgrade --update && \
 
 ENV DOCKER_HOST=tcp://192.168.65.1
 
+ENV M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
+    TOMCAT_HOME=/home/user/tomcat8 \ 
+    PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
+
 EXPOSE 22 8000 8080
 
 USER user
@@ -113,3 +111,4 @@ WORKDIR /projects
 CMD sudo /usr/bin/ssh-keygen -A && \
     sudo /usr/sbin/sshd -D && \
     tail -f /dev/null
+    

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -90,11 +90,15 @@ RUN apk upgrade --update && \
     echo -e "${PASS}\n${PASS}" | passwd user && \
     chown -R user /home/user/
 
-ENV DOCKER_HOST=tcp://192.168.65.1 \
-    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION \
-    TOMCAT_HOME=/home/user/tomcat8
+RUN mkdir /usr/che \
+    && wget -qO /usr/che/che https://raw.githubusercontent.com/eclipse/che/CHE-2116/che.sh \
+    && chmod +x /usr/che/che
 
-ENV PATH=${PATH}:${JAVA_HOME}/bin:${M2_HOME}/bin
+ENV DOCKER_HOST=tcp://192.168.65.1 \
+    M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION 
+
+ENV PATH=${PATH}:${JAVA_HOME}/bin:${M2_HOME}/bin:/usr/che
+
 
 EXPOSE 22 8000 8080
 

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -24,7 +24,7 @@ ENV JAVA_VERSION_MAJOR=8 \
 
 # do all in one step
 RUN apk upgrade --update && \
-    apk add --update libstdc++ curl ca-certificates bash openssh sudo unzip bash openssl && \
+    apk add --update libstdc++ curl ca-certificates bash openssh sudo unzip openssl && \
     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
     apk add --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \

--- a/alpine_jdk8/Dockerfile
+++ b/alpine_jdk8/Dockerfile
@@ -104,5 +104,6 @@ WORKDIR /projects
 
 CMD sudo /usr/bin/ssh-keygen -A && \
     sudo /usr/sbin/sshd -D && \
+    sudo su - && \
     tail -f /dev/null
     


### PR DESCRIPTION
This provides a base image on alpine that includes docker 1.12 which is necessary for running docker commands from within a Che container against a host.

1: Update to alpine 3.4
2: Use base docker image for 1.12
3: Configure container to use host docker daemon